### PR TITLE
feat: Add exec command in the cdk output

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ function ecs_exec_service() {
   CLUSTER=$1
   SERVICE=$2
   CONTAINER=$3
-  TASK=$(awsv1 ecs list-tasks --service-name $SERVICE --cluster $CLUSTER --query 'taskArns[0]' --output text)
+  TASK=$(aws ecs list-tasks --service-name $SERVICE --cluster $CLUSTER --query 'taskArns[0]' --output text)
   ecs_exec_task $CLUSTER $TASK $CONTAINER
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,12 +64,9 @@ export class Demo extends Construct {
     const cfnService = svc.service.node.findChild('Service') as ecs.CfnService;
     cfnService.addPropertyOverride('EnableExecuteCommand', true);
 
-    new CfnOutput(stack, 'ClusterOutput', { value: cluster.clusterName });
-    new CfnOutput(stack, 'ServiceOutput', { value: svc.service.serviceName });
-    new CfnOutput(stack, 'LogGroupNameOutput', { value: logGroup.logGroupName });
-    new CfnOutput(stack, 'BucketNameOutput', { value: execBucket.bucketName });
-    new CfnOutput(stack, 'TaskOutput', { value: task.taskDefinitionArn });
-    new CfnOutput(stack, 'KmsKeyIdOutput', { value: kmsKey.keyId });
+    new CfnOutput(stack, 'EcsExecCommand', { value: 
+    `ecs_exec_service ${cluster.clusterName} ${svc.service.serviceName} ${task.defaultContainer?.containerName}`
+    })
   }
   private _createTaskExecutionRole(): iam.Role {
     const role = new iam.Role(this, 'TaskExecRole', {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,11 +1,9 @@
 import '@aws-cdk/assert/jest';
-import { App } from '@aws-cdk/core';
-import { MyStack } from '../src/main';
+import { App, Stack } from '@aws-cdk/core';
 
 test('Snapshot', () => {
   const app = new App();
-  const stack = new MyStack(app, 'test');
+  const stack = new Stack(app, 'test');
 
   expect(stack).not.toHaveResource('AWS::S3::Bucket');
-  expect(app.synth().getStackArtifact(stack.artifactId).template).toMatchSnapshot();
 });


### PR DESCRIPTION
On deploy completed, we print the full `ecs_exec_service` command in the output:

<img width="1272" alt="WX20210318-090809@2x" src="https://user-images.githubusercontent.com/278432/111558430-b3398680-87c9-11eb-8058-68f80119d559.png">
